### PR TITLE
Fingerprint all images to allow aggressive caching

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -4,7 +4,7 @@
     {{ partial "head.html" . -}} 
     <meta name="Description" content="{{.Params.description}}">
     <meta property="og:title" content="{{.Title}}">
-    {{$thumbImage := .Page.Resources.GetMatch .Params.thumbnail -}}
+    {{$thumbImage := .Page.Resources.GetMatch .Params.thumbnail | fingerprint -}}
     <meta property="og:image" content="{{$thumbImage.Permalink}}">
     <meta property="og:image:width" content="{{$thumbImage.Width}}">
     <meta property="og:image:height" content="{{$thumbImage.Height}}">

--- a/layouts/shortcodes/sfffig.html
+++ b/layouts/shortcodes/sfffig.html
@@ -1,4 +1,4 @@
-{{- $image := .Page.Resources.GetMatch (.Get "src") -}}
+{{- $image := .Page.Resources.GetMatch (.Get "src") | fingerprint -}}
 {{- /* These image sizes were taken from gatsby */ -}}
 {{- $tinyImage := $image.Resize "148x" -}}
 {{- $smallImage := cond (ge $image.Width "295") ($image.Resize "295x") $image -}}


### PR DESCRIPTION
Previously images loaded at URLs like:

```
/how-to-undervolt-gpu/kill-a-watt.png
```

Now the image hash is included in the URL

```
/how-to-undervolt-gpu/kill-a-watt.946b15cf74a370d49f99a057846a9788ca818990dbc21d3d678b4f3e26300a5e.png
```

The upside is that extremely aggressive caching can be used, as if the
image changed then it's hash (and thus URL) will change.

The downside is that this won't allow others to hotlink images. I'm ok
with this tradeoff as either the images should be rehosted or the
article directly linked.

The other downside is that if someone is reading an article and the site
is updated then images that have not yet loaded will 404 out as the HTML
could be referencing deleted images. I think this would be a rare
occurrence as I'd have to update an image as a user is starting to read
an article (though it is possible someone could land on the page, store
in a tab for 6 weeks, and then come back and start scrolling).