### PR TITLE
Cloudflare to transmit asset classes with browserTTL

### DIFF
--- a/workers-site/index.js
+++ b/workers-site/index.js
@@ -1,81 +1,42 @@
-// 100% GENERATED FROM `wrangler init --site my-static-site`
-import { getAssetFromKV, mapRequestToAsset } from '@cloudflare/kv-asset-handler'
+import { getAssetFromKV, mapRequestToAsset } from '@cloudflare/kv-asset-handler';
 
-/**
- * The DEBUG flag will do two things that help during development:
- * 1. we will skip caching on the edge, which makes it easier to
- *    debug.
- * 2. we will return an error message on exception in your Response rather
- *    than the default 404.html page.
- */
-const DEBUG = false
+const assetCacheControl = { browserTTL: 8640000 };
 
 addEventListener('fetch', event => {
-  try {
-    event.respondWith(handleEvent(event))
-  } catch (e) {
-    if (DEBUG) {
-      return event.respondWith(
-        new Response(e.message || e.toString(), {
-          status: 500,
-        }),
-      )
-    }
-    event.respondWith(new Response('Internal Error', { status: 500 }))
-  }
+  event.respondWith(handleEvent(event));
 })
 
-async function handleEvent(event) {
-  const url = new URL(event.request.url)
-  let options = {}
-
-  /**
-   * You can add custom logic to how we fetch your assets
-   * by configuring the function `mapRequestToAsset`
-   */
-  // options.mapRequestToAsset = handlePrefix(/^\/docs/)
-
-  try {
-    if (DEBUG) {
-      // customize caching
-      options.cacheControl = {
-        bypassCache: true,
-      }
-    }
-    return await getAssetFromKV(event, options)
-  } catch (e) {
-    // if an error is thrown try to serve the asset at 404.html
-    if (!DEBUG) {
-      try {
-        let notFoundResponse = await getAssetFromKV(event, {
-          mapRequestToAsset: req => new Request(`${new URL(req.url).origin}/404.html`, req),
-        })
-
-        return new Response(notFoundResponse.body, { ...notFoundResponse, status: 404 })
-      } catch (e) {}
-    }
-
-    return new Response(e.message || e.toString(), { status: 500 })
-  }
+// By default the kv-asset-handler does not send a cache control header back in
+// the response (interestingly enough, it used to). Not sending a cache control
+// header isn't the worst as the browser will still work with the etag in the
+// response and check on future requests if the resource had been modified at
+// all. One can still get a 100% lighthouse score with this approach. However,
+// lighthouse will recommend setting a cache policy for static assets, as
+// sending no request is better than sending a request, no matter how small
+// (eg: a 304 Not Modified).
+//
+// Our hugo setup fingerprints all assets, js, css, and images, so our worker
+// will detect the incoming request's file extension and if it matches an asset
+// class, we add the cache control header. Else we return undefined, which will
+// trigger cloudflare's default behavior (no cache control header, but still
+// transmit etags).
+function calcCacheControl(event) {
+    const parsedUrl = new URL(event.request.url)
+    const pathname = parsedUrl.pathname
+    const extension = pathname.split('.').pop();
+    const isCacheable = ["js", "css", "png", "jpg", "jpeg"].indexOf(extension) !== -1;
+    return isCacheable ? assetCacheControl : undefined;
 }
 
-/**
- * Here's one example of how to modify a request to
- * remove a specific prefix, in this case `/docs` from
- * the url. This can be useful if you are deploying to a
- * route on a zone, or if you only want your static content
- * to exist at a specific path.
- */
-function handlePrefix(prefix) {
-  return request => {
-    // compute the default (e.g. / -> index.html)
-    let defaultAssetKey = mapRequestToAsset(request)
-    let url = new URL(defaultAssetKey.url)
-
-    // strip the prefix from the path for lookup
-    url.pathname = url.pathname.replace(prefix, '/')
-
-    // inherit all other props from the default request
-    return new Request(url.toString(), defaultAssetKey)
+async function handleEvent(event) {
+  try {
+    const cacheControl = calcCacheControl(event);
+    return await getAssetFromKV(event, { mapRequestToAsset, cacheControl });
+  } catch (e) {
+    let pathname = new URL(event.request.url).pathname;
+    return new Response(`"${pathname}" not found`, {
+      status: 404,
+      statusText: 'not found',
+    });
   }
 }


### PR DESCRIPTION
Previously cloudflare wouldn't send back a cache control header on our
fingerprinted assets, letting the browser now to the asset would never
expire (so no need to send a request if the resource is referenced)

By default the kv-asset-handler does not send a cache control header back in
the response (interestingly enough, it used to). Not sending a cache control
header isn't the worst as the browser will still work with the etag in the
response and check on future requests if the resource had been modified at
all. One can still get a 100% lighthouse score with this approach. However,
lighthouse will recommend setting a cache policy for static assets, as
sending no request is better than sending a request, no matter how small
(eg: a 304 Not Modified).

Our hugo setup fingerprints all assets, js, css, and images, so our worker
will detect the incoming request's file extension and if it matches an asset
class, we add the cache control header. Else we return undefined, which will
trigger cloudflare's default behavior (no cache control header, but still
transmit etags).